### PR TITLE
Fixing multiple 'dynamic' constant exports

### DIFF
--- a/client/app/(ee)/settings/logs/page.tsx
+++ b/client/app/(ee)/settings/logs/page.tsx
@@ -14,5 +14,4 @@ export default async function Logs() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
 

--- a/client/app/settings/datasets/[id]/page.tsx
+++ b/client/app/settings/datasets/[id]/page.tsx
@@ -32,5 +32,5 @@ export default async function DatasetDetailsPage({ params }: PageProps) {
     </>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/datasets/page.tsx
+++ b/client/app/settings/datasets/page.tsx
@@ -55,5 +55,5 @@ export default async function Datasets() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/page.tsx
+++ b/client/app/settings/page.tsx
@@ -5,5 +5,5 @@ export const dynamic = 'force-dynamic';
 export default function Home() {
   redirect("/settings/datasets");
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/workspaces/addspaces/page.tsx
+++ b/client/app/settings/workspaces/addspaces/page.tsx
@@ -31,5 +31,5 @@ export default async function AddSpaces() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/workspaces/editspaces/page.tsx
+++ b/client/app/settings/workspaces/editspaces/page.tsx
@@ -27,5 +27,5 @@ export default async function EditWorkSpaces({ searchParams }) {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 

--- a/client/app/settings/workspaces/page.tsx
+++ b/client/app/settings/workspaces/page.tsx
@@ -50,5 +50,5 @@ export default async function WorkSpaces() {
     </div>
   );
 }
-export const dynamic='force-dynamic';
+
 


### PR DESCRIPTION
Fixing multiple 'dynamic' constant exports. Looks like two people pushed two different fixes for a previous issue which resulted in duplicate exports in all of these files.

